### PR TITLE
Don't clear the context stack in pop

### DIFF
--- a/src/std/http/Client.zig
+++ b/src/std/http/Client.zig
@@ -2469,14 +2469,6 @@ pub const Ctx = struct {
         if (self.stack) |stack| {
             const allocator = self.alloc();
             const func = stack.pop(allocator, null);
-
-            defer {
-                if (self.stack != null and self.stack.?.next == null) {
-                    allocator.destroy(self.stack.?);
-                    self.stack = null;
-                }
-            }
-
             return @call(.auto, func, .{ self, res });
         }
         unreachable;


### PR DESCRIPTION
Currently, when pop returns, the stack is deinitialized if empty. I assume this is an optimize to free memory ASAP, without having to wait for deinit.

But currently, the only way to free a Ctx is from a callback being executed within pop. You have to call `ctx.deinit` within `ctx.pop`, and you possibly have other things to clean up too, like deallocating a heap-allocated Ctx. This makes _any_ operations after @call returns dangerous.

Consider this code:
https://github.com/lightpanda-io/browser/blob/6ae4ed9fc33eb82d7206d52692d8616737d11bf5/src/xhr/xhr.zig#L617

This calls ctx.deinit() _within_ a call to ctx.pop, it then sets the union referencing ctx to null. After that point, the ctx variable/memory should not be used.